### PR TITLE
Make Wizard a not low-pop gamemode

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -8,8 +8,8 @@
 /datum/game_mode/wizard
 	name = "wizard"
 	config_tag = "wizard"
-	required_players = 2
-	required_players_secret = 10
+	required_players = 25
+	required_players_secret = 25
 	required_enemies = 1
 	recommended_enemies = 1
 	rage = 0


### PR DESCRIPTION
Wizards are way too destructive for low pop, with spells like blink, fireball, ethereal jaunt and pretty much anything else they can shit all over a low pop round and turn it into wiztended. Which isn't fun for anyone.
